### PR TITLE
parse other URLs out of a Figshare Article

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+This document record significant changes to the project
+
+### 0.5.0 2022-06-08
+
+- add public/private URLs to ArticleLink
+
 ### 0.4.1 2022-03-01
 
 - bump dependency versions. Spring 5.2 -> 5.3.16

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # figshare-client-java
 Java bindings to Figshare API
 
-This project uses Spring-REST and Spring Social to provide a Java client to the Figshare API.
+This project uses Spring-REST to provide a Java client to the Figshare API.
 
 It is not complete, but supports basic Article operations and File upload.
-
 
 ### Installing into a Maven repository
 
@@ -60,10 +59,10 @@ If a personal token is used, this will take precedence over any OAuth2 access to
 
 Simply supply a personal token as a system property and autowire the Figshare API into your application:
 
-```java
+ ```java
  @Autowired
  private Figshare figshare;
-```
+ ```
 
 To set up Figshare bean, if using Java configuration, use the configuration as is from SpringTestConfig. E.g.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>figshare-client-java</artifactId>
-    <version>0.4.1</version>
+    <version>0.5.0</version>
     <build>
         <resources></resources>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -111,7 +111,7 @@
         </dependency>
     </dependencies>
     <properties>
-        <spring.version>5.3.16</spring.version>
+        <spring.version>5.3.20</spring.version>
         <jackson.version>2.12.5</jackson.version>
     </properties>
 </project>

--- a/src/main/java/com/researchspace/figshare/converters/StringToUrlDeserialiser.java
+++ b/src/main/java/com/researchspace/figshare/converters/StringToUrlDeserialiser.java
@@ -13,26 +13,26 @@ import java.util.Optional;
 
 public class StringToUrlDeserialiser extends StdDeserializer {
 
-        private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     public StringToUrlDeserialiser() {
         this(null);
     }
 
-        public StringToUrlDeserialiser(Class clazz) {
-            super(clazz);
-        }
+    public StringToUrlDeserialiser(Class clazz) {
+        super(clazz);
+    }
 
-        @Override
-        public URL deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-            ObjectCodec objectCodec = jsonParser.getCodec();
-            JsonNode node = objectCodec.readTree(jsonParser);
-            String stringUrl = node.asText();
-            if (StringUtils.isBlank(stringUrl)) {
-                return null;
-            } else {
-               return new URL(stringUrl);
-            }
+    @Override
+    public URL deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        ObjectCodec objectCodec = jsonParser.getCodec();
+        JsonNode node = objectCodec.readTree(jsonParser);
+        String stringUrl = node.asText();
+        if (StringUtils.isBlank(stringUrl)) {
+            return null;
+        } else {
+            return new URL(stringUrl);
         }
+    }
 
 }

--- a/src/main/java/com/researchspace/figshare/converters/StringToUrlDeserialiser.java
+++ b/src/main/java/com/researchspace/figshare/converters/StringToUrlDeserialiser.java
@@ -1,0 +1,38 @@
+package com.researchspace.figshare.converters;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
+
+public class StringToUrlDeserialiser extends StdDeserializer {
+
+        private static final long serialVersionUID = 1L;
+
+    public StringToUrlDeserialiser() {
+        this(null);
+    }
+
+        public StringToUrlDeserialiser(Class clazz) {
+            super(clazz);
+        }
+
+        @Override
+        public URL deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+            ObjectCodec objectCodec = jsonParser.getCodec();
+            JsonNode node = objectCodec.readTree(jsonParser);
+            String stringUrl = node.asText();
+            if (StringUtils.isBlank(stringUrl)) {
+                return null;
+            } else {
+               return new URL(stringUrl);
+            }
+        }
+
+}

--- a/src/main/java/com/researchspace/figshare/model/ArticlePresenter.java
+++ b/src/main/java/com/researchspace/figshare/model/ArticlePresenter.java
@@ -1,7 +1,11 @@
 package com.researchspace.figshare.model;
 
+import java.net.URL;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.researchspace.figshare.converters.StringToUrlDeserialiser;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,5 +33,23 @@ public class ArticlePresenter {
 	private List<String> references;
 	
 	private FigshareLicense license;
+
+	@JsonProperty("url_public_html")
+	@JsonDeserialize(using = StringToUrlDeserialiser.class)
+	private URL publicURL;
+
+	@JsonProperty("url_private_html")
+	@JsonDeserialize(using = StringToUrlDeserialiser.class)
+	private URL privateURL;
+
+	@JsonProperty("url_public_api")
+	@JsonDeserialize(using = StringToUrlDeserialiser.class)
+	private URL publicApiURL;
+
+	@JsonProperty("url_private_api")
+	@JsonDeserialize(using = StringToUrlDeserialiser.class)
+	private URL privateApiURL;
+
+
 
 }

--- a/src/test/java/com/researchspace/figshare/api/FigshareAcceptanceTest.java
+++ b/src/test/java/com/researchspace/figshare/api/FigshareAcceptanceTest.java
@@ -131,7 +131,7 @@ public class FigshareAcceptanceTest extends AbstractJUnit4SpringContextTests{
 		assertTrue(article2.getLicense().getUrl().toString().toUpperCase().contains("GPL"));
 		assertTrue(article2.getCategories().stream()
 				.filter((cat)->cat.getTitle().equals("Software Engineering")).findFirst().isPresent());
-		
+		assertNotNull(article2.getPrivateURL());
 		assertTrue(templateProxy.deleteArticle(articleLoc.getId()));
 	}
 	
@@ -171,7 +171,9 @@ public class FigshareAcceptanceTest extends AbstractJUnit4SpringContextTests{
 		assertEquals(1, templateProxy.getFiles(articleLoc.getId()).size() );
 		assertTrue(templateProxy.deleteArticle(articleLoc.getId()));	
 	}
-	
+
+	// note this test requires the testing Figshare account to be connected to an Orcid account.
+	// It will fail otherwise.
 	@Test
 	public void testPrivateLinkArticleCRUD() throws IOException {
 		ArticlePost article = createFullArticle();

--- a/src/test/java/com/researchspace/figshare/api/FigshareAcceptanceTest.java
+++ b/src/test/java/com/researchspace/figshare/api/FigshareAcceptanceTest.java
@@ -39,190 +39,192 @@ import com.researchspace.figshare.model.PrivateArticleLink;
 
 /**
  * Makes test calls using personal token
- * @author rspace
  *
+ * @author rspace
  */
 
 @FigshareSpringTest
-public class FigshareAcceptanceTest extends AbstractJUnit4SpringContextTests{
+public class FigshareAcceptanceTest extends AbstractJUnit4SpringContextTests {
 
-	Logger log = LoggerFactory.getLogger(FigshareAcceptanceTest.class);
-	
-	private Figshare templateProxy;
-	@Autowired
-	private Figshare template;
-	
-	File dataFile = new File ("src/test/resources/ResizablePng.zip");
-	File smallFile = new File ("src/test/resources/bytes.dat");
-	
-	// proxy object to interpose a delay between requests
-	private class DelayAPIExecutor <T> implements InvocationHandler {
-		private static final int ONE_SECOND = 1000;
-		private T object;
-		public DelayAPIExecutor(T object) {
-			super();
-			this.object = object;
-		}
-		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-			Thread.currentThread().sleep(ONE_SECOND);
-			try {
-				return method.invoke(object, args);
-			} catch (InvocationTargetException e) {
-				throw e.getTargetException();
-			}
-		}
-	}
-	
-	@Before
-	public void setUp() throws Exception {
-		templateProxy = setUpDelayExecutingProxy();
-		FileUtils.writeByteArrayToFile(smallFile, new byte[] {1, 2, 3, 4, 5 });
-	}
+    Logger log = LoggerFactory.getLogger(FigshareAcceptanceTest.class);
 
-	private Figshare setUpDelayExecutingProxy() {
-		return (Figshare)Proxy
+    private Figshare templateProxy;
+    @Autowired
+    private Figshare template;
+
+    File dataFile = new File("src/test/resources/ResizablePng.zip");
+    File smallFile = new File("src/test/resources/bytes.dat");
+
+    // proxy object to interpose a delay between requests
+    private class DelayAPIExecutor<T> implements InvocationHandler {
+        private static final int ONE_SECOND = 1000;
+        private T object;
+
+        public DelayAPIExecutor(T object) {
+            super();
+            this.object = object;
+        }
+
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            Thread.currentThread().sleep(ONE_SECOND);
+            try {
+                return method.invoke(object, args);
+            } catch (InvocationTargetException e) {
+                throw e.getTargetException();
+            }
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        templateProxy = setUpDelayExecutingProxy();
+        FileUtils.writeByteArrayToFile(smallFile, new byte[]{1, 2, 3, 4, 5});
+    }
+
+    private Figshare setUpDelayExecutingProxy() {
+        return (Figshare) Proxy
                 .newProxyInstance(FigshareAcceptanceTest.class.getClassLoader(),
-                		template.getClass().getInterfaces(), new DelayAPIExecutor<Figshare>(template));
-	}
+                        template.getClass().getInterfaces(), new DelayAPIExecutor<Figshare>(template));
+    }
 
-	@After
-	public void tearDown() throws Exception {
-	}
+    @After
+    public void tearDown() throws Exception {
+    }
 
-	@Test
-	public void testTest() {		
-		assertTrue(templateProxy.test());
-	}
-	
-	@Test
-	public void testCategories() {		
-		List<FigshareCategory> categories = templateProxy.getCategories(false);
-		assertTrue(categories.size() > 20);
-		// this is to see if any parent categories are returned in the list - currently they're not.
-		List<FigshareCategory> parents = new ArrayList<>();
-		  categories.stream().forEach(cat->{
-			parents.addAll(categories.stream().filter(
-					c->c.getId().equals(cat.getParentId())).collect(Collectors.toList()));
-		});
-		parents.stream().forEach(c->System.out.println(c));	
-	}
-	
-	@Test
-	public void testLicenses() {		
-		List<FigshareLicense> licenses = templateProxy.getLicenses(false);
-		assertTrue(licenses.size() > 5);
-		licenses.stream().forEach(lic->System.out.println(lic));
-	}
-	
-	@Test
-	public void testProfile() {		
-		Account account = templateProxy.account();
-		assertNotNull(account.getEmail());
-	}
-	
-	
-	@Test
-	public void testCreateAndDeleteArticle () throws IOException {
-		ArticlePost article = createFullArticle();
-		Location articleLoc = templateProxy.createArticle(article);
-		assertNotNull(articleLoc.getId());
-		ArticlePresenter article2 = templateProxy.getArticle(articleLoc.getId());
-		assertEquals(article.getDescription(), article2.getDescription());
-		assertTrue(article2.getLicense().getUrl().toString().toUpperCase().contains("GPL"));
-		assertTrue(article2.getCategories().stream()
-				.filter((cat)->cat.getTitle().equals("Software Engineering")).findFirst().isPresent());
-		assertNotNull(article2.getPrivateURL());
-		assertTrue(templateProxy.deleteArticle(articleLoc.getId()));
-	}
-	
-	@Test
-	public void testCreateAndDeleteFile () throws IOException {
-		ArticlePost article = createFullArticle();
-		Location articleLoc = templateProxy.createArticle(article);
-		Location file = null;
-		try {
-		 file = templateProxy.uploadFile(articleLoc.getId(), smallFile);
-		}catch (Exception e) {
-			log.warn(e.getMessage());
-		}
-		assertEquals(1, templateProxy.getFiles(articleLoc.getId()).size());
-		if(file != null) {
-			assertTrue(templateProxy.deleteFile(articleLoc.getId(), file.getId()));
-			assertEquals(0, templateProxy.getFiles(articleLoc.getId()).size());
-		}
-		assertTrue(templateProxy.deleteArticle(articleLoc.getId()));	
-	}
-	
-	@Test
-	public void testDropFilesAndReplace () throws IOException {
-		ArticlePost article = createFullArticle();
-		Location articleLoc = templateProxy.createArticle(article);
-		Location file1 = null, file2 = null;
-		try {
-		 file1 = templateProxy.uploadFile(articleLoc.getId(), smallFile);
-		 file2 = templateProxy.uploadFile(articleLoc.getId(), dataFile);
-		}catch (Exception e) {
-			log.warn(e.getMessage());
-		}
-		assertEquals(2, templateProxy.getFiles(articleLoc.getId()).size() );
-		Location newFile = templateProxy.dropFilesAndReplace(articleLoc.getId(), smallFile);
-		assertFalse(newFile.getId().equals(file1.getId()));
-		assertFalse(newFile.getId().equals(file2.getId()));
-		assertEquals(1, templateProxy.getFiles(articleLoc.getId()).size() );
-		assertTrue(templateProxy.deleteArticle(articleLoc.getId()));	
-	}
+    @Test
+    public void testTest() {
+        assertTrue(templateProxy.test());
+    }
 
-	// note this test requires the testing Figshare account to be connected to an Orcid account.
-	// It will fail otherwise.
-	@Test
-	public void testPrivateLinkArticleCRUD() throws IOException {
-		ArticlePost article = createFullArticle();
-		Location articleLoc = templateProxy.createArticle(article);
-		assertNotNull(articleLoc.getId());
-		try {
-			assertEquals(0, templateProxy.getPrivateArticleLinks(articleLoc.getId()).size());
-			PrivateArticleLink privateLink = templateProxy.createPrivateArticleLink(articleLoc.getId());
-			assertNotNull(privateLink.getWeblink());
-			assertEquals(1, templateProxy.getPrivateArticleLinks(articleLoc.getId()).size());
-			// calling again just overwrites
-			privateLink = templateProxy.createPrivateArticleLink(articleLoc.getId());
-			List<PrivateArticle> links = templateProxy.getPrivateArticleLinks(articleLoc.getId());
-			String key = links.get(0).getId();
-			templateProxy.deletePrivateArticleLink(articleLoc.getId(), key);
-			assertEquals(0, templateProxy.getPrivateArticleLinks(articleLoc.getId()).size());	
-		} finally {
-			// tidy up
-			templateProxy.deleteArticle(articleLoc.getId());
-		}
-	}
-	
-	@Test
-	@Ignore
-	//TODO this seems to get published, so we should try to unpublish or cancel this test
-	public void testPublishArticle() throws IOException {
-		ArticlePost article = createFullArticle();
-		Location articleLoc = templateProxy.createArticle(article);
-		assertNotNull(articleLoc.getId());
-		// set to fail, so we don't publish lots of things in tests
-		try {
-			FigshareResponse<Location> published = templateProxy.publishArticle(articleLoc.getId());
-			assertNotNull(published.getError());
-			log.warn(published.getError().toString());
-		} finally {
-			// tidy up
-			templateProxy.deleteArticle(articleLoc.getId());
-		}
-	}
-	
+    @Test
+    public void testCategories() {
+        List<FigshareCategory> categories = templateProxy.getCategories(false);
+        assertTrue(categories.size() > 20);
+        // this is to see if any parent categories are returned in the list - currently they're not.
+        List<FigshareCategory> parents = new ArrayList<>();
+        categories.stream().forEach(cat -> {
+            parents.addAll(categories.stream().filter(
+                    c -> c.getId().equals(cat.getParentId())).collect(Collectors.toList()));
+        });
+        parents.stream().forEach(c -> System.out.println(c));
+    }
 
-	private ArticlePost createFullArticle() {
-		ArticlePost article = ArticlePost.builder().title("Title").description("Description")
-				.author(new Author("Bob Jones", null))
-				.tags(Arrays.asList(new String []{"rspace"}))
-				.categories(Arrays.asList(new Integer []{21,23}))
-				.license(4) //GPL
-				.build();
-		return article;
-	}
+    @Test
+    public void testLicenses() {
+        List<FigshareLicense> licenses = templateProxy.getLicenses(false);
+        assertTrue(licenses.size() > 5);
+        licenses.stream().forEach(lic -> System.out.println(lic));
+    }
+
+    @Test
+    public void testProfile() {
+        Account account = templateProxy.account();
+        assertNotNull(account.getEmail());
+    }
+
+
+    @Test
+    public void testCreateAndDeleteArticle() throws IOException {
+        ArticlePost article = createFullArticle();
+        Location articleLoc = templateProxy.createArticle(article);
+        assertNotNull(articleLoc.getId());
+        ArticlePresenter article2 = templateProxy.getArticle(articleLoc.getId());
+        assertEquals(article.getDescription(), article2.getDescription());
+        assertTrue(article2.getLicense().getUrl().toString().toUpperCase().contains("GPL"));
+        assertTrue(article2.getCategories().stream()
+                .filter((cat) -> cat.getTitle().equals("Software Engineering")).findFirst().isPresent());
+        assertNotNull(article2.getPrivateURL());
+        assertTrue(templateProxy.deleteArticle(articleLoc.getId()));
+    }
+
+    @Test
+    public void testCreateAndDeleteFile() throws IOException {
+        ArticlePost article = createFullArticle();
+        Location articleLoc = templateProxy.createArticle(article);
+        Location file = null;
+        try {
+            file = templateProxy.uploadFile(articleLoc.getId(), smallFile);
+        } catch (Exception e) {
+            log.warn(e.getMessage());
+        }
+        assertEquals(1, templateProxy.getFiles(articleLoc.getId()).size());
+        if (file != null) {
+            assertTrue(templateProxy.deleteFile(articleLoc.getId(), file.getId()));
+            assertEquals(0, templateProxy.getFiles(articleLoc.getId()).size());
+        }
+        assertTrue(templateProxy.deleteArticle(articleLoc.getId()));
+    }
+
+    @Test
+    public void testDropFilesAndReplace() throws IOException {
+        ArticlePost article = createFullArticle();
+        Location articleLoc = templateProxy.createArticle(article);
+        Location file1 = null, file2 = null;
+        try {
+            file1 = templateProxy.uploadFile(articleLoc.getId(), smallFile);
+            file2 = templateProxy.uploadFile(articleLoc.getId(), dataFile);
+        } catch (Exception e) {
+            log.warn(e.getMessage());
+        }
+        assertEquals(2, templateProxy.getFiles(articleLoc.getId()).size());
+        Location newFile = templateProxy.dropFilesAndReplace(articleLoc.getId(), smallFile);
+        assertFalse(newFile.getId().equals(file1.getId()));
+        assertFalse(newFile.getId().equals(file2.getId()));
+        assertEquals(1, templateProxy.getFiles(articleLoc.getId()).size());
+        assertTrue(templateProxy.deleteArticle(articleLoc.getId()));
+    }
+
+    // note this test requires the testing Figshare account to be connected to an Orcid account.
+    // It will fail otherwise.
+    @Test
+    public void testPrivateLinkArticleCRUD() throws IOException {
+        ArticlePost article = createFullArticle();
+        Location articleLoc = templateProxy.createArticle(article);
+        assertNotNull(articleLoc.getId());
+        try {
+            assertEquals(0, templateProxy.getPrivateArticleLinks(articleLoc.getId()).size());
+            PrivateArticleLink privateLink = templateProxy.createPrivateArticleLink(articleLoc.getId());
+            assertNotNull(privateLink.getWeblink());
+            assertEquals(1, templateProxy.getPrivateArticleLinks(articleLoc.getId()).size());
+            // calling again just overwrites
+            privateLink = templateProxy.createPrivateArticleLink(articleLoc.getId());
+            List<PrivateArticle> links = templateProxy.getPrivateArticleLinks(articleLoc.getId());
+            String key = links.get(0).getId();
+            templateProxy.deletePrivateArticleLink(articleLoc.getId(), key);
+            assertEquals(0, templateProxy.getPrivateArticleLinks(articleLoc.getId()).size());
+        } finally {
+            // tidy up
+            templateProxy.deleteArticle(articleLoc.getId());
+        }
+    }
+
+    @Test
+    @Ignore
+    //TODO this seems to get published, so we should try to unpublish or cancel this test
+    public void testPublishArticle() throws IOException {
+        ArticlePost article = createFullArticle();
+        Location articleLoc = templateProxy.createArticle(article);
+        assertNotNull(articleLoc.getId());
+        // set to fail, so we don't publish lots of things in tests
+        try {
+            FigshareResponse<Location> published = templateProxy.publishArticle(articleLoc.getId());
+            assertNotNull(published.getError());
+            log.warn(published.getError().toString());
+        } finally {
+            // tidy up
+            templateProxy.deleteArticle(articleLoc.getId());
+        }
+    }
+
+
+    private ArticlePost createFullArticle() {
+        ArticlePost article = ArticlePost.builder().title("Title").description("Description")
+                .author(new Author("Bob Jones", null))
+                .tags(Arrays.asList(new String[]{"rspace"}))
+                .categories(Arrays.asList(new Integer[]{21, 23}))
+                .license(4) //GPL
+                .build();
+        return article;
+    }
 
 }

--- a/src/test/java/com/researchspace/figshare/converters/StringToUrlDeserialiserTest.java
+++ b/src/test/java/com/researchspace/figshare/converters/StringToUrlDeserialiserTest.java
@@ -1,0 +1,50 @@
+package com.researchspace.figshare.converters;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.researchspace.figshare.model.ArticlePresenter;
+import org.junit.Test;
+
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+public class StringToUrlDeserialiserTest {
+
+    @Test
+    public void convertStringToUrl() throws MalformedURLException, JsonProcessingException {
+        ArticlePresenter presenter = ArticlePresenter.builder()
+                .publicURL(anyURL("public"))
+                .publicApiURL(anyURL("publicApi"))
+                .privateURL(anyURL("private"))
+                .privateApiURL(anyURL("privateapi")).build();
+        ObjectMapper mapper = new ObjectMapper();
+        String testJson = mapper.writeValueAsString(presenter);
+
+        ArticlePresenter articlePresenterDeserialised = mapper.readValue(testJson, ArticlePresenter.class);
+        assertEquals(articlePresenterDeserialised.getPrivateURL(), presenter.getPrivateURL());
+        assertEquals(articlePresenterDeserialised.getPublicApiURL(), presenter.getPublicApiURL());
+        assertEquals(articlePresenterDeserialised.getPublicURL()    , presenter.getPublicURL());
+        assertEquals(articlePresenterDeserialised.getPrivateApiURL(), presenter.getPrivateApiURL());
+    }
+
+    @Test
+    public void convertStringToUrlHandlesNullValues() throws MalformedURLException, JsonProcessingException {
+
+        ObjectMapper mapper = new ObjectMapper();
+        ArticlePresenter articlePresenterDeserialised = mapper.readValue("{}", ArticlePresenter.class);
+        assertNull(articlePresenterDeserialised.getPrivateURL() );
+        assertNull(articlePresenterDeserialised.getPublicApiURL());
+        assertNull(articlePresenterDeserialised.getPublicURL() );
+        assertNull(articlePresenterDeserialised.getPrivateApiURL());
+    }
+
+    private URL anyURL(String prefix) throws MalformedURLException {
+        return new URL("https://" + prefix + ".somewhere.com");
+    }
+
+}

--- a/src/test/java/com/researchspace/figshare/converters/StringToUrlDeserialiserTest.java
+++ b/src/test/java/com/researchspace/figshare/converters/StringToUrlDeserialiserTest.java
@@ -28,7 +28,7 @@ public class StringToUrlDeserialiserTest {
         ArticlePresenter articlePresenterDeserialised = mapper.readValue(testJson, ArticlePresenter.class);
         assertEquals(articlePresenterDeserialised.getPrivateURL(), presenter.getPrivateURL());
         assertEquals(articlePresenterDeserialised.getPublicApiURL(), presenter.getPublicApiURL());
-        assertEquals(articlePresenterDeserialised.getPublicURL()    , presenter.getPublicURL());
+        assertEquals(articlePresenterDeserialised.getPublicURL(), presenter.getPublicURL());
         assertEquals(articlePresenterDeserialised.getPrivateApiURL(), presenter.getPrivateApiURL());
     }
 
@@ -37,9 +37,9 @@ public class StringToUrlDeserialiserTest {
 
         ObjectMapper mapper = new ObjectMapper();
         ArticlePresenter articlePresenterDeserialised = mapper.readValue("{}", ArticlePresenter.class);
-        assertNull(articlePresenterDeserialised.getPrivateURL() );
+        assertNull(articlePresenterDeserialised.getPrivateURL());
         assertNull(articlePresenterDeserialised.getPublicApiURL());
-        assertNull(articlePresenterDeserialised.getPublicURL() );
+        assertNull(articlePresenterDeserialised.getPublicURL());
         assertNull(articlePresenterDeserialised.getPrivateApiURL());
     }
 


### PR DESCRIPTION
This is part of process  to make link retrieval more robust. Figshare require accounts to be linked to Orcid in order to generate 'private article links'. This PR adds ability to parse out other sorts of links from a Figshare article