### PR TITLE
RSDEV-1081: figshare fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Instructions — figshare-client-java
+
+## Integration Tests
+
+- **Always run the acceptance/integration tests** (`FigshareAcceptanceTest`) after making changes — do not rely on unit tests alone.
+- The tests require a **Figshare personal API token**. Ask the user for it before running.
+- Pass the token via Maven system property:
+  ```
+  mvn test -Dtest="FigshareAcceptanceTest" -DfigshareToken=<TOKEN>
+  ```
+- `testPrivateLinkArticleCRUD` may fail with `403 Insufficient permissions` if the Figshare account is not linked to an ORCID account — this is a known pre-existing issue, not a code bug.
+
+## Security
+
+- The Figshare API token is a **secret**. Never commit it to the repository, embed it in source files, or push it to Git in any form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 This document record significant changes to the project
 
+## 0.7.1 2026-04-27
+
+- fix `IOException: stream is closed` on POST requests by adding `Content-Type: application/json` header
+- fix `LoggingResponseErrorHandler` prematurely closing response body stream; use `BufferingClientHttpRequestFactory` to allow body to be read after error handling
+
 ## 0.7.0 2026-01-19
 
 - update Account model class, following Figshare API changes (Account.active prop type int -> boolean)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ This document record significant changes to the project
 ## 0.7.1 2026-04-27
 
 - fix `IOException: stream is closed` on POST requests by adding `Content-Type: application/json` header
-- fix `LoggingResponseErrorHandler` prematurely closing response body stream; use `BufferingClientHttpRequestFactory` to allow body to be read after error handling
+- fix response body re-read after error handling by using `BufferingClientHttpRequestFactory` to buffer the body so both `LoggingResponseErrorHandler` and `RestTemplate` can read it safely; limit buffering to metadata calls to avoid duplicating large file uploads in memory
 
 ## 0.7.0 2026-01-19
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>figshare-client-java</artifactId>
-    <version>0.7.0</version>
+    <version>0.7.1</version>
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>

--- a/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
+++ b/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
@@ -83,9 +83,10 @@ public final class FigshareTemplate implements Figshare {
 				new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
 		configureRestTemplate();
 		// File operations get a plain (non-buffered) RestTemplate to avoid
-		// duplicating large upload payloads in memory.
+		// duplicating large upload payloads in memory. DefaultResponseErrorHandler
+		// (the default) is used so errors throw proper Spring exceptions without
+		// consuming/closing the response stream.
 		RestTemplate fileRestTemplate = new RestTemplate();
-		fileRestTemplate.setErrorHandler(new LoggingResponseErrorHandler());
 		this.fileOps = new FileOperationsImpl(fileRestTemplate, accessToken);
 		this.utils = new FigshareUtils();
 	}

--- a/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
+++ b/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
@@ -24,6 +24,8 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -77,7 +79,8 @@ public final class FigshareTemplate implements Figshare {
 	}
 
 	private void init() {
-		this.restTemplate = new RestTemplate();
+		this.restTemplate = new RestTemplate(
+				new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
 		configureRestTemplate();
 		this.fileOps = new FileOperationsImpl(restTemplate, accessToken);
 		this.utils = new FigshareUtils();
@@ -96,7 +99,7 @@ public final class FigshareTemplate implements Figshare {
 	public Location createArticle(ArticlePost article) {
 		String url = utils.createPath("/account/articles");
 		String json = marshalObject(article);
-		HttpEntity<String> entity = utils.createHttpEntity(json, accessToken);
+		HttpEntity<String> entity = utils.createJsonHttpEntity(json, accessToken);
 		ResponseEntity<String> resp = getRestTemplate().postForEntity(url, entity, String.class);
 		log.debug(resp.toString());
 		// can't convert directly as content type of returned is text/html?
@@ -108,7 +111,7 @@ public final class FigshareTemplate implements Figshare {
 	public Location createFile(Long articleId, File file) {
 		String url = utils.createPath("/account/articles/{articleId}/files");
 		ObjectNode node = createFileJson(file);
-		HttpEntity<String> entity = utils.createHttpEntity(marshalObject(node), accessToken);
+		HttpEntity<String> entity = utils.createJsonHttpEntity(marshalObject(node), accessToken);
 		ResponseEntity<String> resp = getRestTemplate().postForEntity(url, entity, String.class, articleId);
 		log.debug(resp.toString());
 		// can't convert directly as content type of returned is text/html?

--- a/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
+++ b/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
@@ -82,7 +82,11 @@ public final class FigshareTemplate implements Figshare {
 		this.restTemplate = new RestTemplate(
 				new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
 		configureRestTemplate();
-		this.fileOps = new FileOperationsImpl(restTemplate, accessToken);
+		// File operations get a plain (non-buffered) RestTemplate to avoid
+		// duplicating large upload payloads in memory.
+		RestTemplate fileRestTemplate = new RestTemplate();
+		fileRestTemplate.setErrorHandler(new LoggingResponseErrorHandler());
+		this.fileOps = new FileOperationsImpl(fileRestTemplate, accessToken);
 		this.utils = new FigshareUtils();
 	}
 

--- a/src/main/java/com/researchspace/figshare/impl/FigshareUtils.java
+++ b/src/main/java/com/researchspace/figshare/impl/FigshareUtils.java
@@ -37,11 +37,28 @@ public class FigshareUtils {
 		
 	}
 
+	/**
+	 * Creates an HttpEntity with Content-Type set to application/json, for use
+	 * with POST/PUT requests that send a JSON body.
+	 */
+	HttpEntity<String> createJsonHttpEntity(String json, String personalToken) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		if (!StringUtils.isEmpty(personalToken)) {
+			addAPIKeyToHeader(headers, personalToken);
+		}
+		return new HttpEntity<>(json, headers);
+	}
+
 	private void addAPIKeyToHeader(HttpHeaders headers, String personalToken) {
 		headers.add("Authorization", " token " + personalToken);
 	}
 	
 	 <T> T readFromString(ResponseEntity<String> resp, Class<T> clazz) {
+		if (resp.getBody() == null) {
+			return null;
+		}
 		ObjectMapper mapper = new ObjectMapper();
 		T obj = null;
 		try {

--- a/src/main/java/com/researchspace/figshare/impl/LoggingResponseErrorHandler.java
+++ b/src/main/java/com/researchspace/figshare/impl/LoggingResponseErrorHandler.java
@@ -1,12 +1,12 @@
 package com.researchspace.figshare.impl;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.HttpClientErrorException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,13 +23,15 @@ public class LoggingResponseErrorHandler extends DefaultResponseErrorHandler {
 	@Override
 	public void handleError(ClientHttpResponse response) throws IOException {
 		log.error("Response error: {} {}", response.getStatusCode(), response.getStatusText());
-		try (InputStream bodyStream = response.getBody()) {
-			String body = new String(bodyStream.readAllBytes(), StandardCharsets.UTF_8);
-			log.error(body);
-		}
+		byte[] bodyBytes = response.getBody().readAllBytes();
+		log.error(new String(bodyBytes, StandardCharsets.UTF_8));
 		// if forbidden we have a bad access token and should throw exception.
-		if(response.getStatusCode().equals(HttpStatus.FORBIDDEN)) {
-			super.handleError(response);
+		// We throw directly here rather than delegating to super.handleError,
+		// because the stream has already been consumed above.
+		if (response.getStatusCode().equals(HttpStatus.FORBIDDEN)) {
+			throw HttpClientErrorException.create(
+					HttpStatus.FORBIDDEN, response.getStatusText(),
+					response.getHeaders(), bodyBytes, StandardCharsets.UTF_8);
 		}
 	}
 

--- a/src/main/java/com/researchspace/figshare/impl/LoggingResponseErrorHandler.java
+++ b/src/main/java/com/researchspace/figshare/impl/LoggingResponseErrorHandler.java
@@ -1,9 +1,8 @@
 package com.researchspace.figshare.impl;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
@@ -24,14 +23,10 @@ public class LoggingResponseErrorHandler extends DefaultResponseErrorHandler {
 	@Override
 	public void handleError(ClientHttpResponse response) throws IOException {
 		log.error("Response error: {} {}", response.getStatusCode(), response.getStatusText());
-		StringBuilder buffer = new StringBuilder();
 		try (InputStream bodyStream = response.getBody()) {
-			BufferedReader reader = new BufferedReader(new InputStreamReader(bodyStream));
-			while (reader.ready()) {
-				buffer.append(reader.readLine());
-			}
+			String body = new String(bodyStream.readAllBytes(), StandardCharsets.UTF_8);
+			log.error(body);
 		}
-		log.error(buffer.toString());
 		// if forbidden we have a bad access token and should throw exception.
 		if(response.getStatusCode().equals(HttpStatus.FORBIDDEN)) {
 			super.handleError(response);

--- a/src/test/java/com/researchspace/figshare/impl/FigshareTemplateTest.java
+++ b/src/test/java/com/researchspace/figshare/impl/FigshareTemplateTest.java
@@ -1,0 +1,133 @@
+package com.researchspace.figshare.impl;
+
+import com.researchspace.figshare.model.ArticlePost;
+import com.researchspace.figshare.model.Location;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+/**
+ * Unit tests for FigshareTemplate using MockRestServiceServer.
+ *
+ * These tests reproduce the RSDEV-1081 bug: POST requests to the Figshare API
+ * were missing the Content-Type: application/json header. Combined with a
+ * LoggingResponseErrorHandler that closed the response body stream, this caused
+ * "java.io.IOException: stream is closed" when the server rejected the request.
+ */
+public class FigshareTemplateTest {
+
+    private static final String TEST_TOKEN = "test-token";
+    private static final String BASE_URL = "https://api.figshare.com/v2";
+    private static final String ARTICLE_URL = BASE_URL + "/account/articles";
+    private static final long ARTICLE_ID = 12345L;
+    private static final long FILE_ID = 67890L;
+
+    private FigshareTemplate figshareTemplate;
+    private MockRestServiceServer mockServer;
+
+    @Before
+    public void setUp() {
+        figshareTemplate = new FigshareTemplate(TEST_TOKEN);
+        mockServer = MockRestServiceServer.createServer(figshareTemplate.getRestTemplate());
+    }
+
+    /**
+     * Reproduces the core bug from RSDEV-1081: createArticle must send
+     * Content-Type: application/json so the Figshare API accepts the request.
+     * Before the fix this test failed because the header was missing.
+     */
+    @Test
+    public void testCreateArticle_sendsContentTypeApplicationJson() {
+        mockServer.expect(requestTo(ARTICLE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withStatus(HttpStatus.CREATED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"location\": \"https://api.figshare.com/v2/account/articles/" + ARTICLE_ID + "\"}"));
+
+        ArticlePost article = ArticlePost.builder().title("Test article").description("Description").build();
+        Location location = figshareTemplate.createArticle(article);
+
+        assertNotNull(location);
+        assertEquals(Long.valueOf(ARTICLE_ID), location.getId());
+        mockServer.verify();
+    }
+
+    /**
+     * When the server returns a 400 error, LoggingResponseErrorHandler logs it and
+     * returns without throwing (for non-403 errors). The caller receives a null
+     * location. Before the fix, the handler's stream-close bug caused a
+     * ResourceAccessException with "stream is closed" instead.
+     */
+    @Test
+    public void testCreateArticle_400ResponseIsLoggedWithoutException() {
+        mockServer.expect(requestTo(ARTICLE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withBadRequest()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"message\": \"Invalid article data\", \"code\": 400}"));
+
+        ArticlePost article = ArticlePost.builder().title("Test").build();
+        // Should not throw ResourceAccessException("stream is closed")
+        Location location = figshareTemplate.createArticle(article);
+        assertNull(location);
+        mockServer.verify();
+    }
+
+    /**
+     * 403 Forbidden must propagate as an exception (bad token scenario).
+     */
+    @Test(expected = HttpClientErrorException.class)
+    public void testCreateArticle_403ResponseThrowsException() {
+        mockServer.expect(requestTo(ARTICLE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.FORBIDDEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"message\": \"Forbidden\", \"code\": 403}"));
+
+        ArticlePost article = ArticlePost.builder().title("Test").build();
+        figshareTemplate.createArticle(article);
+    }
+
+    /**
+     * createFile must also send Content-Type: application/json — it sends a JSON
+     * body describing the file metadata. Before the fix this header was missing.
+     */
+    @Test
+    public void testCreateFile_sendsContentTypeApplicationJson() throws IOException {
+        File tempFile = File.createTempFile("figshare-test", ".dat");
+        tempFile.deleteOnExit();
+        Files.write(tempFile.toPath(), new byte[]{1, 2, 3, 4, 5});
+
+        String fileUrl = ARTICLE_URL + "/" + ARTICLE_ID + "/files";
+        mockServer.expect(requestTo(fileUrl))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withStatus(HttpStatus.CREATED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"location\": \"" + BASE_URL + "/account/articles/" + ARTICLE_ID + "/files/" + FILE_ID + "\"}"));
+
+        Location fileLocation = figshareTemplate.createFile(ARTICLE_ID, tempFile);
+
+        assertNotNull(fileLocation);
+        assertEquals(Long.valueOf(FILE_ID), fileLocation.getId());
+        mockServer.verify();
+    }
+}

--- a/src/test/java/com/researchspace/figshare/impl/FigshareTemplateTest.java
+++ b/src/test/java/com/researchspace/figshare/impl/FigshareTemplateTest.java
@@ -57,7 +57,7 @@ public class FigshareTemplateTest {
     public void testCreateArticle_sendsContentTypeApplicationJson() {
         mockServer.expect(requestTo(ARTICLE_URL))
                 .andExpect(method(HttpMethod.POST))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andRespond(withStatus(HttpStatus.CREATED)
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"location\": \"https://api.figshare.com/v2/account/articles/" + ARTICLE_ID + "\"}"));
@@ -119,7 +119,7 @@ public class FigshareTemplateTest {
         String fileUrl = ARTICLE_URL + "/" + ARTICLE_ID + "/files";
         mockServer.expect(requestTo(fileUrl))
                 .andExpect(method(HttpMethod.POST))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andRespond(withStatus(HttpStatus.CREATED)
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"location\": \"" + BASE_URL + "/account/articles/" + ARTICLE_ID + "/files/" + FILE_ID + "\"}"));

--- a/src/test/java/com/researchspace/figshare/impl/FigshareTemplateTest.java
+++ b/src/test/java/com/researchspace/figshare/impl/FigshareTemplateTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -94,7 +95,7 @@ public class FigshareTemplateTest {
     /**
      * 403 Forbidden must propagate as an exception (bad token scenario).
      */
-    @Test(expected = HttpClientErrorException.class)
+    @Test
     public void testCreateArticle_403ResponseThrowsException() {
         mockServer.expect(requestTo(ARTICLE_URL))
                 .andExpect(method(HttpMethod.POST))
@@ -103,7 +104,14 @@ public class FigshareTemplateTest {
                         .body("{\"message\": \"Forbidden\", \"code\": 403}"));
 
         ArticlePost article = ArticlePost.builder().title("Test").build();
-        figshareTemplate.createArticle(article);
+        try {
+            figshareTemplate.createArticle(article);
+            fail("Expected HttpClientErrorException for 403 Forbidden");
+        } catch (HttpClientErrorException e) {
+            assertEquals(HttpStatus.FORBIDDEN, e.getStatusCode());
+        } finally {
+            mockServer.verify();
+        }
     }
 
     /**


### PR DESCRIPTION
> This fix was produced by a GitHub Copilot AI agent on behalf of the user.

Fixes RSDEV-1081: Figshare deposit failing in production with `IOException: stream is closed` on POST to `/account/articles`.

## Root causes

- **Missing `Content-Type: application/json`** on POST requests — Figshare API rejected the body
- **`LoggingResponseErrorHandler` consumed and closed the response stream**, then `RestTemplate` tried to deserialize from the already-closed stream

## Changes

- `FigshareUtils`: added `createJsonHttpEntity()` setting `Content-Type: application/json`; null-guard in `readFromString()`
- `FigshareTemplate`: `BufferingClientHttpRequestFactory` for metadata calls; separate plain `RestTemplate` for `FileOperationsImpl` (avoids buffering large uploads); `FileOperationsImpl` uses `DefaultResponseErrorHandler` (no stream-close risk)
- `LoggingResponseErrorHandler`: reads body bytes first, logs them, then throws `HttpClientErrorException.create(...)` directly for 403 — no re-read of the consumed stream
- `FigshareTemplateTest`: 4 regression tests; `contentTypeCompatibleWith()` for charset resilience; 403 test uses try/catch/finally with `mockServer.verify()` and asserts `FORBIDDEN` status
- `CHANGELOG.md`: accurate description of the buffering mechanism
- `AGENTS.md`: project-level agent instructions for integration tests and token handling
- Version `0.7.0` → `0.7.1`