### PR TITLE
RSDEV-444: Upgrade figshare-client-java to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 This document record significant changes to the project
 
-## 1.0.0 2026-04-29
+## 1.0.0 2026-07-28
 - Spring 6 / Hibernate 6 / Jakarta migration (RSDEV-444)
 - Upgrade to rspace-parent 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This document record significant changes to the project
 
+## 1.0.0 2026-04-29
+- Spring 6 / Hibernate 6 / Jakarta migration (RSDEV-444)
+- Upgrade to rspace-parent 3.0.0
+
 ## 0.7.1 2026-04-27
 
 - fix `IOException: stream is closed` on POST requests by adding `Content-Type: application/json` header

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>3.0.0</version>
+        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>figshare-client-java</artifactId>
-    <version>0.7.0</version>
+    <version>1.0.0</version>
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>2.1.3</version>
+        <version>3.0.0</version>
     </parent>
 
     <repositories>

--- a/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
+++ b/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
@@ -284,7 +286,7 @@ public final class FigshareTemplate implements Figshare {
 		String url = utils.createPath("/account/articles/{id}/private_links/{private_link_id}");
 		ResponseEntity<String> resp = getRestTemplate().exchange(url,
 				HttpMethod.DELETE, createEmptyEntity(), String.class, articleId, uniqueLinkKey);
-		log.debug(resp.getStatusCode().name());
+		log.debug(resp.getStatusCode().toString());
 	}
 
 	// personal token used for testing and is added to the Authorisation Header.

--- a/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
+++ b/src/main/java/com/researchspace/figshare/impl/FigshareTemplate.java
@@ -22,8 +22,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;

--- a/src/main/java/com/researchspace/figshare/model/FigshareError.java
+++ b/src/main/java/com/researchspace/figshare/model/FigshareError.java
@@ -1,7 +1,5 @@
 package com.researchspace.figshare.model;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Data;
 import org.springframework.http.HttpStatusCode;
 

--- a/src/main/java/com/researchspace/figshare/model/FigshareError.java
+++ b/src/main/java/com/researchspace/figshare/model/FigshareError.java
@@ -3,10 +3,11 @@ package com.researchspace.figshare.model;
 import org.springframework.http.HttpStatus;
 
 import lombok.Data;
+import org.springframework.http.HttpStatusCode;
 
 @Data
 public class FigshareError {
 	String message, code;
-	HttpStatus status;
+	HttpStatusCode status;
 
 }


### PR DESCRIPTION
Upgrade figshare-client-java to 1.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Bumps parent pom and switches `FigshareError.status` from `HttpStatus` to `HttpStatusCode` for Spring 6 compatibility. No downstream callers of the changed type.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
